### PR TITLE
Set F34 release - avoid seccomp/clone/clone3 issue

### DIFF
--- a/Dockerfile_fedora-postgres
+++ b/Dockerfile_fedora-postgres
@@ -1,4 +1,4 @@
-FROM docker.io/library/fedora:latest
+FROM docker.io/library/fedora:34
 MAINTAINER alexander@redhat.com
 RUN yum install -y postgresql-server
 USER postgres


### PR DESCRIPTION
When this Dockerfile was originally composed ~4 years ago, Glibc 2.34 and a system call named `clone3` didn't exist. Pinning this to an older Fedora release will avoid the seccomp --> `curl: (6) getaddrinfo() thread failed to start` error from occurring.

Please see:
https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
https://github.com/containers/podman/issues/11862
...for more details.